### PR TITLE
商品情報編集機能の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,63 +1,62 @@
-
 class ItemsController < ApplicationController
-  before_action :new_action, only: [:new] 
-  before_action :set_item, only: [:edit, :update, :show]
-  before_action :move_to_index, except: [:index, :show]
- 
-  def index 
-     @items = Item.includes(:user).order("created_at DESC")
-   end
- 
-   def new
-   end
- 
-   def create
-     @item = Item.new(item_params)
-     if @item.save
+ before_action :new_action, only: [:new] 
+ before_action :set_item, only: [:show, :update]
+ before_action :move_to_index, only: [:edit]
+
+ def index 
+    @items = Item.includes(:user).order("created_at DESC")
+  end
+
+  def new
+  end
+
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
        redirect_to root_path
-     else
-       render :new
-     end
-   end
- 
-   def edit
-   end
- 
-   def update
-     if @item.update(item_params)
-        redirect_to root_path
-     else 
-        render :edit
-     end
-   end
-   
-   def show
-   end 
- 
-   private
- 
-   def item_params
-     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id, :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
-   end
- 
-   def new_action
-     if user_signed_in?
-       @item = Item.new
-     else
-       redirect_to new_user_session_path
-     end
-   end
- 
- 
-   def set_item
-     @item = Item.find(params[:id])
-   end
- 
-   def move_to_index
-     unless user_signed_in? && current_user.id == @item.user_id
-       redirect_to root_path
-     end
-   end
- 
- end
- 
+    else 
+       render :edit
+    end
+  end
+  
+  def show
+  end 
+
+  private
+
+  def item_params
+    params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id, :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
+  end
+
+  def new_action
+    if user_signed_in?
+      @item = Item.new
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless user_signed_in? && current_user.id == @item.user_id
+      redirect_to root_path
+    end
+  end
+
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,4 @@
 class ItemsController < ApplicationController
- before_action :set_item, only: [:edit, :show]
- before_action :move_to_index, except: [:index, :show]
 
  def index 
     @items = Item.includes(:user).order("created_at DESC")
@@ -24,6 +22,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
+    if user_signed_in? && current_user.id == @item.user_id
+    else
+      redirect_to root_path
+    end
   end
 
   def update
@@ -36,22 +39,13 @@ class ItemsController < ApplicationController
   end
   
   def show
+    @item = Item.find(params[:id])
   end 
 
   private
 
   def item_params
     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id, :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
-  end
-
-  def set_item
-    @item = Item.find(params[:id])
-  end
-
-  def move_to_index
-    unless user_signed_in? && current_user.id == @item.user_id
-      redirect_to root_path
-    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,3 +1,4 @@
+
 class ItemsController < ApplicationController
   before_action :new_action, only: [:new] 
   before_action :set_item, only: [:edit, :show]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 
 class ItemsController < ApplicationController
   before_action :new_action, only: [:new] 
-  before_action :set_item, only: [:edit, :show]
+  before_action :set_item, only: [:edit, :update, :show]
   before_action :move_to_index, except: [:index, :show]
  
   def index 
@@ -24,7 +24,6 @@ class ItemsController < ApplicationController
    end
  
    def update
-     @item = Item.find(params[:id])
      if @item.update(item_params)
         redirect_to root_path
      else 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,51 +1,63 @@
 class ItemsController < ApplicationController
-
- def index 
-    @items = Item.includes(:user).order("created_at DESC")
-  end
-
-  def new
-    if user_signed_in?
-      @item = Item.new
-    else
-      redirect_to new_user_session_path
-    end
-  end
-
-  def create
-    @item = Item.new(item_params)
-    if @item.save
-      redirect_to root_path
-    else
-      render :new
-    end
-  end
-
-  def edit
-    @item = Item.find(params[:id])
-    if user_signed_in? && current_user.id == @item.user_id
-    else
-      redirect_to root_path
-    end
-  end
-
-  def update
-    @item = Item.find(params[:id])
-    if @item.update(item_params)
+  before_action :new_action, only: [:new] 
+  before_action :set_item, only: [:edit, :show]
+  before_action :move_to_index, except: [:index, :show]
+ 
+  def index 
+     @items = Item.includes(:user).order("created_at DESC")
+   end
+ 
+   def new
+   end
+ 
+   def create
+     @item = Item.new(item_params)
+     if @item.save
        redirect_to root_path
-    else 
-       render :edit
-    end
-  end
-  
-  def show
-    @item = Item.find(params[:id])
-  end 
-
-  private
-
-  def item_params
-    params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id, :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
-  end
-
-end
+     else
+       render :new
+     end
+   end
+ 
+   def edit
+   end
+ 
+   def update
+     @item = Item.find(params[:id])
+     if @item.update(item_params)
+        redirect_to root_path
+     else 
+        render :edit
+     end
+   end
+   
+   def show
+   end 
+ 
+   private
+ 
+   def item_params
+     params.require(:item).permit(:image, :item_name, :item_info, :item_category_id, :item_sales_status_id, :item_shipping_fee_status_id, :item_prefecture_id, :item_scheduled_delivery_id, :item_price).merge(user_id: current_user.id)
+   end
+ 
+   def new_action
+     if user_signed_in?
+       @item = Item.new
+     else
+       redirect_to new_user_session_path
+     end
+   end
+ 
+ 
+   def set_item
+     @item = Item.find(params[:id])
+   end
+ 
+   def move_to_index
+     unless user_signed_in? && current_user.id == @item.user_id
+       redirect_to root_path
+     end
+   end
+ 
+ end
+ 


### PR DESCRIPTION
What
①before_actionの記述2行削除して、@item = Item.find(params[:id])の記述をshow, editそれぞれに戻した。
②editアクションにif文で出品者かどうか条件分岐を追加。
Why
①前述だと未ログイン時に「出品する」をクリックするとトップページへ遷移されてしまい、newアクションの条件分岐の意味がなくなるため。(newアクションの条件分岐を活かしたい)
②before_actionの記述を削除したので、URLで直接商品編集画面にアクセスされてもトップページに遷移されるようにeditアクションに条件分岐を記述しなければならないため。